### PR TITLE
Add machine learning sales forecasting to cash planning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ altair>=5.0.0
 openpyxl>=3.1.0
 requests>=2.31.0
 streamlit-plotly-events>=0.0.6
+statsmodels>=0.14.0
+tensorflow>=2.12.0


### PR DESCRIPTION
## Summary
- add ARIMA and LSTM training utilities with forecast and savings helpers
- record new dependencies for statsmodels and TensorFlow
- surface machine learning sales forecast controls in the cash tab and apply results to cash planning visuals

## Testing
- python -m compileall data_processing.py app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cfbe373c8323b840b9e20952e9c7