### PR TITLE
Fix gross margin alert handling for zero values

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -1333,7 +1333,7 @@ def build_alerts(
         alerts.append(f"解約率が{churn_rate:.1%}と高水準です。定期顧客のフォローを見直してください。")
 
     gross_margin_rate = kpi_summary.get("gross_margin_rate") if kpi_summary else None
-    if gross_margin_rate and gross_margin_rate < thresholds["gross_margin_rate"]:
+    if gross_margin_rate is not None and pd.notna(gross_margin_rate) and gross_margin_rate < thresholds["gross_margin_rate"]:
         alerts.append(f"粗利率が{gross_margin_rate:.1%}と目標を下回っています。商品ミックスを確認しましょう。")
 
     if cashflow_forecast is not None and not cashflow_forecast.empty:

--- a/tests/test_build_alerts.py
+++ b/tests/test_build_alerts.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from data_processing import build_alerts
+
+
+def test_build_alerts_emits_gross_margin_alert_for_zero_margin():
+    monthly_summary = pd.DataFrame([{"sales_amount": 1000}])
+    kpi_summary = {"gross_margin_rate": 0.0}
+    cashflow_forecast = pd.DataFrame({"cash_balance": [1000]})
+
+    alerts = build_alerts(monthly_summary, kpi_summary, cashflow_forecast)
+
+    assert any("粗利率" in alert for alert in alerts)


### PR DESCRIPTION
## Summary
- ensure gross margin alerts validate non-null values before comparing thresholds
- add a regression test confirming zero gross margin triggers an alert

## Testing
- pytest tests/test_build_alerts.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cfc26a3c8323ba6058878d165d6c