### PR TITLE
Clamp simulated cost ratio below one to protect gross profit

### DIFF
--- a/app.py
+++ b/app.py
@@ -8035,7 +8035,14 @@ def main() -> None:
 
         col1, col2, col3, col4 = st.columns(4)
         sales_growth = col1.slider("売上成長率", min_value=-0.5, max_value=0.5, value=0.05, step=0.01)
-        cost_adj = col2.slider("原価率変動", min_value=-0.1, max_value=0.1, value=0.0, step=0.01)
+        cost_adj = col2.slider(
+            "原価率変動",
+            min_value=-0.1,
+            max_value=0.1,
+            value=0.0,
+            step=0.01,
+            help="粗利がマイナスにならないよう、シミュレーションでは原価率を最大99%に制限します。",
+        )
         sga_change = col3.slider("販管費変動率", min_value=-0.3, max_value=0.3, value=0.0, step=0.01)
         extra_ad = col4.number_input("追加広告費", min_value=0.0, value=0.0, step=50_000.0, format="%.0f")
 

--- a/data_processing.py
+++ b/data_processing.py
@@ -1234,7 +1234,7 @@ def simulate_pl(
 
     new_sales = current_sales * (1 + sales_growth_rate)
     base_cost_ratio = current_cogs / current_sales if current_sales else 0
-    new_cost_ratio = max(0, base_cost_ratio + cost_rate_adjustment)
+    new_cost_ratio = min(0.99, max(0, base_cost_ratio + cost_rate_adjustment))
     new_cogs = new_sales * new_cost_ratio
     new_gross = new_sales - new_cogs
     new_sga = current_sga * (1 + sga_change_rate) + additional_ad_cost

--- a/tests/test_simulate_pl.py
+++ b/tests/test_simulate_pl.py
@@ -1,0 +1,41 @@
+"""Tests for the PL simulation helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from data_processing import simulate_pl
+
+
+class SimulatePLTestCase(unittest.TestCase):
+    """Regression tests for :func:`simulate_pl`."""
+
+    def test_cost_ratio_is_capped_below_one(self) -> None:
+        """Even at maximum adjustment the gross profit should stay non-negative."""
+
+        base_pl = {
+            "sales": 1_000.0,
+            "cogs": 950.0,
+            "sga": 400.0,
+            "gross_profit": 50.0,
+        }
+
+        result = simulate_pl(
+            base_pl,
+            sales_growth_rate=0.0,
+            cost_rate_adjustment=0.1,
+            sga_change_rate=0.0,
+            additional_ad_cost=0.0,
+        )
+
+        scenario_sales = result.loc[result["項目"] == "売上高", "シナリオ"].iloc[0]
+        scenario_cogs = result.loc[result["項目"] == "売上原価", "シナリオ"].iloc[0]
+        scenario_gross = result.loc[result["項目"] == "粗利", "シナリオ"].iloc[0]
+
+        self.assertGreaterEqual(scenario_gross, 0.0)
+        scenario_cost_ratio = scenario_cogs / scenario_sales if scenario_sales else 0.0
+        self.assertLessEqual(scenario_cost_ratio, 0.99)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cap the simulated cost ratio at 99% so the PL scenario cannot overspend sales on COGS
- document the cap in the cashflow simulator cost rate slider help text
- add a regression test ensuring gross profit stays non-negative at the maximum slider adjustment

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e0cfc2a6108323b75f55f44b777523